### PR TITLE
Allow mount of local drive with HA Core >2021.2.3

### DIFF
--- a/sambanas/apparmor.txt
+++ b/sambanas/apparmor.txt
@@ -1,0 +1,48 @@
+#include <tunables/global>
+
+profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+  
+  capability,
+  file,
+  mount,
+  umount,
+  remount,
+
+  capability setgid,
+  capability setuid,
+  capability sys_admin, 
+  capability dac_read_search, 
+  # capability dac_override,
+  # capability sys_rawio,
+
+# S6-Overlay
+  /bin/** ix,
+  /usr/bin/** ix,
+  /usr/lib/bashio/** ix,
+  /etc/s6/** rix,
+  /run/s6/** rix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /init rix,
+  /var/run/** mrwkl,
+  /var/run/ mrwkl,
+  /dev/i2c-1 mrwkl, 
+  # Files required
+  /dev/sda1 mrwkl,
+  /dev/sdb1 mrwkl,
+  /dev/mmcblk0p1 mrwkl,
+  /dev/* mrwkl,
+  /tmp/** mrkwl,
+  
+  # Data access
+  /data/** rw, 
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+ 
+  # docker daemon confinement requires explict allow rule for signal
+  signal (receive) set=(kill,term) peer=/usr/bin/docker,
+
+}

--- a/sambanas/apparmor.txt
+++ b/sambanas/apparmor.txt
@@ -13,8 +13,9 @@ profile addon_samba_nas flags=(attach_disconnected,mediate_deleted) {
   capability setuid,
   capability sys_admin, 
   capability dac_read_search, 
+  capability sys_rawio,
+  capability sys_resource,
   # capability dac_override,
-  # capability sys_rawio,
 
 # S6-Overlay
   /bin/** ix,

--- a/sambanas/apparmor.txt
+++ b/sambanas/apparmor.txt
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile db21ed7f_qbittorrent flags=(attach_disconnected,mediate_deleted) {
+profile addon_samba_nas flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   
   capability,

--- a/sambanas/rootfs/etc/cont-init.d/automount.sh
+++ b/sambanas/rootfs/etc/cont-init.d/automount.sh
@@ -6,7 +6,11 @@ readonly CONF="/etc/samba/smb.conf"
 declare moredisks
 
 # Mount external drive
-if bashio::config.has_value 'moredisks'; then
+bashio::log.info "Protection Mode is $(bashio::addon.protected)"
+if $(bashio::addon.protected) && bashio::config.has_value 'moredisks' ; then
+     bashio::log.warning "MoreDisk ignored because ADDON in Protected Mode!"
+     bashio::config.suggest "protected" "moredisk only work when Protection mode is disabled"
+elif bashio::config.has_value 'moredisks'; then
      bashio::log.warning "MoreDisk option found!"
 
      MOREDISKS=$(bashio::config 'moredisks')

--- a/sambanas/rootfs/etc/cont-init.d/automount.sh
+++ b/sambanas/rootfs/etc/cont-init.d/automount.sh
@@ -6,11 +6,7 @@ readonly CONF="/etc/samba/smb.conf"
 declare moredisks
 
 # Mount external drive
-bashio::log.info "Protection Mode is $(bashio::addon.protected)"
-if $(bashio::addon.protected) && bashio::config.has_value 'moredisks' ; then
-     bashio::log.warning "MoreDisk ignored because ADDON in Protected Mode!"
-     bashio::config.suggest "protected" "moredisk only work when Protection mode is disabled"
-elif bashio::config.has_value 'moredisks'; then
+if bashio::config.has_value 'moredisks'; then
      bashio::log.warning "MoreDisk option found!"
 
      MOREDISKS=$(bashio::config 'moredisks')


### PR DESCRIPTION
Without custom apparmor the local drive doesn't mount with error "mount: /dev_: cannot mount devtmpfs read-only." 

Issue : https://github.com/dianlight/hassio-addons/issues/35#issue-812545546 