### PR TITLE
Create apparmor.txt

### DIFF
--- a/plex/apparmor.txt
+++ b/plex/apparmor.txt
@@ -1,0 +1,48 @@
+#include <tunables/global>
+
+profile 1a32f091-plex flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+  
+  capability,
+  file,
+  mount,
+  umount,
+  remount,
+
+  capability setgid,
+  capability setuid,
+  capability sys_admin, 
+  capability dac_read_search, 
+  # capability dac_override,
+  # capability sys_rawio,
+
+# S6-Overlay
+  /bin/** ix,
+  /usr/bin/** ix,
+  /usr/lib/bashio/** ix,
+  /etc/s6/** rix,
+  /run/s6/** rix,
+  /etc/services.d/** rwix,
+  /etc/cont-init.d/** rwix,
+  /etc/cont-finish.d/** rwix,
+  /init rix,
+  /var/run/** mrwkl,
+  /var/run/ mrwkl,
+  /dev/i2c-1 mrwkl, 
+  # Files required
+  /dev/sda1 mrwkl,
+  /dev/sdb1 mrwkl,
+  /dev/mmcblk0p1 mrwkl,
+  /dev/* mrwkl,
+  /tmp/** mrkwl,
+  
+  # Data access
+  /data/** rw, 
+
+  # suppress ptrace denials when using 'docker ps' or using 'ps' inside a container
+  ptrace (trace,read) peer=docker-default,
+ 
+  # docker daemon confinement requires explict allow rule for signal
+  signal (receive) set=(kill,term) peer=/usr/bin/docker,
+
+}


### PR DESCRIPTION
Adds apparmor.txt to fix the issue of not being able to mount a network drive following the changes of the 2021.2.3 version of HA Core.