### PR TITLE
Update addon configuration with current norms

### DIFF
--- a/RPiMySensor/config.json
+++ b/RPiMySensor/config.json
@@ -6,7 +6,7 @@
   "url": "https://github.com/dianlight/hassio-addons/tree/master/RPiMySensor",
   "arch": ["armhf", "armv7"],
   "_image": "dianlight/rpi-mysensor-gw-{arch}",
-  "startup": "before",
+  "startup": "services",
   "boot": "auto",
   "options": {
     "rebuild": false,  
@@ -49,11 +49,11 @@
     "5300/tcp": "TCP communication port"
   },
   "devices":[
-      "/dev/spidev0.0:/dev/spidev0.0:rwm",
-      "/dev/mem:/dev/mem:rw"
+      "/dev/spidev0.0:rwm",
+      "/dev/mem:rw"
   ],
   "udev": true,
-  "auto_uart": true,
+  "uart": true,
   "privileged": [
       "SYS_RAWIO",
       "SYS_RESOURCE",

--- a/RPiMySensor/config.json
+++ b/RPiMySensor/config.json
@@ -49,8 +49,8 @@
     "5300/tcp": "TCP communication port"
   },
   "devices":[
-      "/dev/spidev0.0:rwm",
-      "/dev/mem:rw"
+      "/dev/spidev0.0",
+      "/dev/mem"
   ],
   "udev": true,
   "uart": true,


### PR DESCRIPTION
```
21-06-26 15:27:48 WARNING (MainThread) [supervisor.addons.validate] Add-on config 'startup' with 'before' is deprecated. Please report this to the maintainer of RPi MySensor Gateway
21-06-26 15:27:48 WARNING (MainThread) [supervisor.addons.validate] Add-on config 'auto_uart' is deprecated, use 'uart'. Please report this to the maintainer of RPi MySensor Gateway
21-06-26 15:27:48 WARNING (MainThread) [supervisor.addons.validate] Add-on config 'devices' use a deprecated format, the new format uses a list of paths only. Please report this to the maintainer of RPi MySensor Gateway
```