### PR TITLE
[Samba NAS] Change startup to system

### DIFF
--- a/sambanas/config.json
+++ b/sambanas/config.json
@@ -5,7 +5,7 @@
   "description": "Expose Home Assistant disc with SMB/CIFS",
   "url": "https://github.com/dianlight/hassio-addons/tree/master/sambanas",
   "arch": ["armhf", "armv7", "aarch64", "amd64", "i386"],
-  "startup": "services",
+  "startup": "system",
   "boot": "auto",
   "init": false,
   "hassio_api": true,


### PR DESCRIPTION
Having the startup as `services` creates a race condition with the Glances add-on, resulting in Glances not seeing the mounted drives.
This causes me to have to always restart the Glances add-on and integration after a full HA restart.