### PR TITLE
Fix path regex for external disks

### DIFF
--- a/sambanas/rootfs/usr/share/tempio/smb.gtpl
+++ b/sambanas/rootfs/usr/share/tempio/smb.gtpl
@@ -42,7 +42,7 @@
    browseable = yes
    writeable = yes
    }}
-{{ if regexMatch "[config|addons|ssl|share|backup|media]" .share }}
+{{ if regexMatch "^(config|addons|ssl|share|backup|media)$" .share }}
    path = /{{- .share}}
 {{ else }}
    path = /media/{{- .share}}


### PR DESCRIPTION
Fixes #84 hopefully.

The existing regex will set the path to / instead of /media as soon as the disk name contains any of the letters in the regex.

This changes the regex so that it matches only if the name of the share is exactly one of the ones in the list.