### PR TITLE
✨ feat(sambanas2): add srat_oauth_broker_url option for hosted OAuth broker

### DIFF
--- a/sambanas2/DOCS.md
+++ b/sambanas2/DOCS.md
@@ -281,13 +281,18 @@ Defaults to `false` (authentication required for SRAT).
 ### Option: `srat_oauth_broker_url` (optional) 🧪 _Experimental_
 
 Base URL of the hosted SRAT OAuth broker used by the **Cloud Sync lab feature**
-(Volumes → Cloud Link). When set (e.g. `https://oauth.example.com`), the SRAT
-web UI offers *"Hosted SRAT OAuth"* in the link wizard's Authorization selector,
-letting users connect a cloud account without creating their own provider app.
-When left empty (default), the variable is not exported and the wizard only
-offers custom-app credentials.
+(Volumes → Cloud Link). The value is passed through to the SRAT binary as-is,
+which resolves it as follows:
 
-Defaults to `""` (disabled).
+- **empty / unset** (default): SRAT falls back to the broker URL baked into
+  its release build — if none was baked in, the hosted flow stays disabled.
+- **`off`**: forces the hosted flow off even when a default is compiled in.
+- **any other value** (e.g. `https://oauth.example.com`): overrides the
+  default. When a working broker URL is in effect, the SRAT web UI offers
+  *"Hosted SRAT OAuth"* in the link wizard's Authorization selector, letting
+  users connect a cloud account without creating their own provider app.
+
+Defaults to `""` (use the SRAT build-time default).
 
 ### Option: `use_external_kernel_modules` (optional) ⚠️ 🧪🔌 _Experimental / Extra Modules_ — _Advanced Users Only_
 

--- a/sambanas2/DOCS.md
+++ b/sambanas2/DOCS.md
@@ -175,6 +175,7 @@ disable_ipv6: true
 leave_front_door_open: false
 factory_reset: false
 use_external_kernel_modules: false
+srat_oauth_broker_url: ""
 ```
 
 **Note**: All configuration options are optional. Only specify options when you want to change the default value.
@@ -276,6 +277,17 @@ It does not grant guest access to SMB shares. Access to your Samba shares contin
 ⚠️ **Security Warning**: Enabling this option exposes the administration UI without login. Anyone on your network could change settings, manage users, and modify shares. Enable only on trusted, isolated networks and only if you fully understand the risk.
 
 Defaults to `false` (authentication required for SRAT).
+
+### Option: `srat_oauth_broker_url` (optional) 🧪 _Experimental_
+
+Base URL of the hosted SRAT OAuth broker used by the **Cloud Sync lab feature**
+(Volumes → Cloud Link). When set (e.g. `https://oauth.example.com`), the SRAT
+web UI offers *"Hosted SRAT OAuth"* in the link wizard's Authorization selector,
+letting users connect a cloud account without creating their own provider app.
+When left empty (default), the variable is not exported and the wizard only
+offers custom-app credentials.
+
+Defaults to `""` (disabled).
 
 ### Option: `use_external_kernel_modules` (optional) ⚠️ 🧪🔌 _Experimental / Extra Modules_ — _Advanced Users Only_
 

--- a/sambanas2/config.yaml
+++ b/sambanas2/config.yaml
@@ -56,6 +56,7 @@ options:
   clean_upgrade_dir: false
   factory_reset: false
   use_external_kernel_modules: false
+  srat_oauth_broker_url: ""
 schema:
   srat_update_channel: list(none|release|prerelease|develop)?
   auto_update: bool?
@@ -65,6 +66,7 @@ schema:
   clean_upgrade_dir: bool?
   factory_reset: bool?
   use_external_kernel_modules: bool?
+  srat_oauth_broker_url: str?
 #image: ghcr.io/dianlight/addon-sambanas2
 udev: true
 #usb: true

--- a/sambanas2/rootfs/etc/s6-overlay/s6-rc.d/srat/run
+++ b/sambanas2/rootfs/etc/s6-overlay/s6-rc.d/srat/run
@@ -11,12 +11,17 @@ trap 'bashio::log.error "srat/run failed at line ${BASH_LINENO[0]} (exit code: $
 export HOSTNAME
 export ADDON_VERSION=$(bashio::app.version)
 
-# Hosted OAuth broker for the rclone cloud-sync lab feature (issue #954):
-# empty option keeps the variable unset so SRAT falls back to custom-app auth.
-if ! bashio::var.is_empty "$(bashio::config 'srat_oauth_broker_url' '')"; then
-  export SRAT_OAUTH_BROKER_URL="$(bashio::config 'srat_oauth_broker_url')"
-  bashio::log.info "SRAT OAuth broker enabled: ${SRAT_OAUTH_BROKER_URL}"
-fi
+# Hosted OAuth broker for the rclone cloud-sync lab feature (issue #954).
+# Exported unconditionally so resolution is centralized in SRAT:
+#   empty  ≡ unset → SRAT's baked-in default applies
+#   "off"          → hosted flow explicitly disabled
+#   value          → overrides the default
+export SRAT_OAUTH_BROKER_URL="$(bashio::config 'srat_oauth_broker_url' '')"
+case "${SRAT_OAUTH_BROKER_URL,,}" in
+  "") ;;
+  off) bashio::log.info "SRAT OAuth broker disabled via sentinel" ;;
+  *) bashio::log.info "SRAT OAuth broker override active" ;;
+esac
 
 ipaddress=$(bashio::app.ip_address)
 

--- a/sambanas2/rootfs/etc/s6-overlay/s6-rc.d/srat/run
+++ b/sambanas2/rootfs/etc/s6-overlay/s6-rc.d/srat/run
@@ -11,6 +11,13 @@ trap 'bashio::log.error "srat/run failed at line ${BASH_LINENO[0]} (exit code: $
 export HOSTNAME
 export ADDON_VERSION=$(bashio::app.version)
 
+# Hosted OAuth broker for the rclone cloud-sync lab feature (issue #954):
+# empty option keeps the variable unset so SRAT falls back to custom-app auth.
+if ! bashio::var.is_empty "$(bashio::config 'srat_oauth_broker_url' '')"; then
+  export SRAT_OAUTH_BROKER_URL="$(bashio::config 'srat_oauth_broker_url')"
+  bashio::log.info "SRAT OAuth broker enabled: ${SRAT_OAUTH_BROKER_URL}"
+fi
+
 ipaddress=$(bashio::app.ip_address)
 
 #bashio::log.info "Wait Samba Server to going up..(max 60s)"


### PR DESCRIPTION
> 85aff22 ✅️ fix(sambanas2): always export SRAT_OAUTH_BROKER_URL, document off sentinel
> 3d52b76 ✨ feat(sambanas2): add srat_oauth_broker_url option for hosted OAuth broker
> 10f2a17 refactor: migrate bashio::addon.* calls to bashio::app.* across s6 services
> 0baf290 🔧 chore: release 2026.8.0-rc13 - Track smartmontools-sdk dev channel (v8.0.2-pre.514) with new monorepo native-core releases - Add Renovate custom manager for SMARTMONTOOLS_SDK_VERSION - Bump add-on version to 2026.8.0-rc13
> f78f9b2 :bug: fix: detect srat-server libc variant and drop old avahi configs
> 5e82acd fix docs
> 2e65c28 🔧 chore: release 2026.8.0-rc13
> 0d8259a ⬆️ Update SambaNas2
> 87579f6 postfix release
> 12b966b :wrench: chore: release 2026.8.0-rc12
> aa4d2c1 docs: migrate Copilot instructions to AGENTS.md
> 548d90e ⬆️ Update SambaNas2
< 9fd7855 ⬆️ Track SMARTMONTOOLS_SDK_VERSION and dnspython in renovate
< deb5742 ⬆️ Update actions/checkout digest to 3d3c42e
< 03b3f06 ⬆️ Update actions/stale action to v11
< 349e3f2 🔄 created local '.github/workflows/opencode-review.yaml' from remote '.github/workflows/opencode-review.yaml'
< 653da84 🔄 created local '.github/workflows/opencode-implement.yaml' from remote '.github/workflows/opencode-implement.yaml'
< ce52d9a 🔄 created local '.github/workflows/opencode-triage-issue.yaml' from remote '.github/workflows/opencode-triage-issue.yaml'
< c7cff8f 🔄 created local '.github/workflows/opencode-triage-pr.yaml' from remote '.github/workflows/opencode-triage-pr.yaml'
< 1dd33fe 🔄 created local '.github/workflows/opencode-triage.yaml' from remote '.github/workflows/opencode-triage.yaml'
< 66f2fd5 🔄 created local '.github/workflows/opencode.yml' from remote '.github/workflows/opencode.yml'
< 5780888 🔄 created local '.github/scripts/resolve-model.sh' from remote '.github/scripts/resolve-model.sh'
< 64e8481 🔄 created local '.github/scripts/auth.sh' from remote '.github/scripts/auth.sh'
< e48c483 🔄 created local '.github/workflows/opencode-issue-handler.yml' from remote '.github/workflows/opencode-issue-handler.yml'
< 68a293a 🔄 created local '.github/workflows/opencode-pr-comment.yml' from remote '.github/workflows/opencode-pr-comment.yml'
< 9752118 🔄 created local '.github/workflows/opencode-pr-review.yml' from remote '.github/workflows/opencode-pr-review.yml'
< 6494948 ci(script) Commit all automatic changes for mergerelease in sambanas2
< 13ab4f0 ⬆️ Update actions/checkout action to v7
< 0928065 ⬆️ Update actions/checkout digest to df4cb1c
< 129a6e7 Update renovate.json to include .devcontainer/**
< ce814b0 ⬆️ Update actions/stale digest to eb5cf3a
< 7379e29 ⬆️ Update dessant/lock-threads digest to 89ae32b
< 34fac4f ⬆️ Update tj-actions/changed-files digest to 24d32ff
< d3eb063 ci(script) Commit all automatic changes for mergerelease in sambanas2
< 71c76a4 ⬆️ Update actions/checkout action to v6
< 862bffb ⬆️ Update actions/checkout digest
< c88a229 ⬆️ Pin home-assistant/builder action to 62a1597
< 76a62fd ⬆️ Update tj-actions/changed-files action to v47
< 200f8ac ci(script) Commit all automatic changes for mergerelease in sambanas2
