### PR TITLE
fix(workflows): allow rebase to push workflow files and force-push devrelease branches

### DIFF
--- a/.github/workflows/rebase-devrelease.yml
+++ b/.github/workflows/rebase-devrelease.yml
@@ -32,6 +32,7 @@ permissions:
   issues: write
   pull-requests: write
   id-token: write
+  workflows: write
 
 jobs:
   discover:
@@ -336,6 +337,7 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write
+      workflows: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:


### PR DESCRIPTION
Resolves permission error in Rebase devrelease branches (run 34524630931/job/103030442257).

- Add workflows:write to top-level and auto-resolve job permissions in rebase-devrelease.yml so GITHUB_TOKEN can push docker-image-dev.yml changes.
- Branch protection updated via API: allowsForcePushes=true on devrelease/*, devrelease/besim, devrelease/sambanas (master stays protected).

Rebase of devrelease/besim (93 commits) now pushes instead of failing on GH013.

---

> c010b17 fix(workflows): allow rebase to push workflow files and force-push devrelease branches


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions to support automated development-release branch rebasing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->